### PR TITLE
Allow installing qt5 and qt6 versions in parallel

### DIFF
--- a/ShowMySky/CMakeLists.txt
+++ b/ShowMySky/CMakeLists.txt
@@ -3,13 +3,13 @@ if(WIN32)
 endif()
 
 add_definitions(-D_USE_MATH_DEFINES)
-add_library(ShowMySky SHARED
+add_library(ShowMySky-Qt${QT_VERSION} SHARED
              api/AtmosphereRenderer.cpp
              AtmosphereRenderer.cpp
              util.cpp
              "${CMAKE_BINARY_DIR}/config.h")
-target_compile_definitions(ShowMySky PRIVATE -DSHOWMYSKY_COMPILING_SHARED_LIB)
-target_link_libraries(ShowMySky PUBLIC Qt${QT_VERSION}::Core Qt${QT_VERSION}::OpenGL PRIVATE version common)
+target_compile_definitions(ShowMySky-Qt${QT_VERSION} PRIVATE -DSHOWMYSKY_COMPILING_SHARED_LIB)
+target_link_libraries(ShowMySky-Qt${QT_VERSION} PUBLIC Qt${QT_VERSION}::Core Qt${QT_VERSION}::OpenGL PRIVATE version common)
 
 set(showmyskyTarget showmysky-cmd)
 
@@ -42,13 +42,13 @@ if(WIN32)
 endif()
 
 install(TARGETS ${showmyskyTarget} DESTINATION "${installBinDir}")
-install(TARGETS ShowMySky
-        EXPORT ShowMySkyConfig
+install(TARGETS ShowMySky-Qt${QT_VERSION}
+        EXPORT ShowMySky-Qt${QT_VERSION}Config
         LIBRARY DESTINATION "${installLibDir}"
         RUNTIME DESTINATION "${installLibDir}"
         ARCHIVE DESTINATION "${installLibDir}"
         INCLUDES DESTINATION "${installIncDir}"
         )
-export(TARGETS ShowMySky NAMESPACE ShowMySky:: FILE "${CMAKE_CURRENT_BINARY_DIR}/ShowMySkyConfig.cmake")
-install(EXPORT ShowMySkyConfig NAMESPACE ShowMySky:: DESTINATION "${installConfDir}/ShowMySky/cmake")
+export(TARGETS ShowMySky-Qt${QT_VERSION} NAMESPACE ShowMySky:: FILE "${CMAKE_CURRENT_BINARY_DIR}/ShowMySky-Qt${QT_VERSION}Config.cmake")
+install(EXPORT ShowMySky-Qt${QT_VERSION}Config NAMESPACE ShowMySky:: DESTINATION "${installConfDir}/ShowMySky-Qt${QT_VERSION}/cmake")
 install(FILES api/Exception.hpp api/AtmosphereRenderer.hpp api/Settings.hpp DESTINATION "${installIncDir}/ShowMySky")

--- a/ShowMySky/GLWidget.cpp
+++ b/ShowMySky/GLWidget.cpp
@@ -156,7 +156,7 @@ void GLWidget::initializeGL()
     {
         if(!ShowMySky_AtmosphereRenderer_create)
         {
-            QLibrary showMySky("ShowMySky");
+            QLibrary showMySky(SHOWMYSKY_LIB_NAME);
             if(!showMySky.load())
                 throw DataLoadError(tr("Failed to load ShowMySky library"));
             const auto abi=reinterpret_cast<const quint32*>(showMySky.resolve("ShowMySky_ABI_version"));

--- a/ShowMySky/api/AtmosphereRenderer.hpp
+++ b/ShowMySky/api/AtmosphereRenderer.hpp
@@ -289,6 +289,17 @@ SHOWMYSKY_DLL_PUBLIC ShowMySky::AtmosphereRenderer*
  * If the value of the symbol doesn't match the value of this constant, the library loaded is incompatible with the header against which the binary was compiled. Mixing incompatible header and library leads to undefined behavior.
  */
 #define ShowMySky_ABI_version (13+QT_VERSION_MAJOR*100000000u)
+
+/**
+ * \brief Name of library to be dlopen()-ed
+ *
+ * It's missing the lib prefix and .so/.dll suffix.
+ */
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+# define SHOWMYSKY_LIB_NAME "ShowMySky-Qt5"
+#else
+# define SHOWMYSKY_LIB_NAME "ShowMySky-Qt6"
+#endif
 }
 
 #endif

--- a/doc/showmysky_api.md
+++ b/doc/showmysky_api.md
@@ -7,7 +7,7 @@ To use ShowMySky from your C++ application, you need to do the following.
 ## Initializing atmosphere renderer
 
 1. **Include the header.** In the C++ source include [<code>\<ShowMySky/AtmosphereRenderer.hpp\></code>](api_2AtmosphereRenderer_8hpp.html) to get access to the relevant classes.
-2. **Load ShowMySky library.** This can be done either by linking to it directly as a usual shared object, or by `dlopen`/`LoadLibrary[Ex]`/`QLibrary::load` etc..
+2. **Load ShowMySky library.** This can be done either by linking to it directly as a usual shared object, or by `dlopen`/`LoadLibrary[Ex]`/`QLibrary::load` etc. The name of the library to load is in the `SHOWMYSKY_LIB_NAME` macro.
 3. **Check ABI verison.** To do this, find a symbol named `ShowMySky_ABI_version` of type `uint32_t` in the loaded library (via `dlsym`/`GetProcAddress`/`QLibrary::resolve` etc.), compare its value with #ShowMySky_ABI_version macro defined in the header included in step 1. If it doesn't match, the library is incompatible with the header, use of such a library has undefined behavior.
 4. **Locate API entry point.** If ABI version is validated successfully in step 3, then find a symbol named #ShowMySky_AtmosphereRenderer_create with the function-pointer type `decltype(ShowMySky_AtmosphereRenderer_create)`.
 5. **Create the settings object.** To provide the renderer with the necessary settings, ShowMySky uses a helper interface, #ShowMySky::Settings. This interface must be implemented by some object in the application. A pointer to this object will later be supplied to the constructor of the renderer.


### PR DESCRIPTION
Why did you decide to open the library at runtime instead of linking to it at build time? The code would be much simpler then