### PR TITLE
Add soname to libShowMySky

### DIFF
--- a/ShowMySky/CMakeLists.txt
+++ b/ShowMySky/CMakeLists.txt
@@ -8,6 +8,8 @@ add_library(ShowMySky SHARED
              AtmosphereRenderer.cpp
              util.cpp
              "${CMAKE_BINARY_DIR}/config.h")
+set_target_properties(ShowMySky PROPERTIES VERSION ${CMAKE_PROJECT_VERSION}
+                      SOVERSION ${PROJECT_VERSION_MAJOR})
 target_compile_definitions(ShowMySky PRIVATE -DSHOWMYSKY_COMPILING_SHARED_LIB)
 target_link_libraries(ShowMySky PUBLIC Qt${QT_VERSION}::Core Qt${QT_VERSION}::OpenGL PRIVATE version common)
 


### PR DESCRIPTION
To meet criteria for packaging CalcMySky into Fedora, I'd like to propose to add soname to libShowMySky. 
Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2131842