### PR TITLE
Fix compilation as subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ if(Eigen3_ADDED)
 	add_library(Eigen3::Eigen IMPORTED INTERFACE)
 	target_include_directories(Eigen3::Eigen INTERFACE ${Eigen3_SOURCE_DIR})
 endif()
-include_directories(${CMAKE_BINARY_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 if(WIN32)
     set(shadersDestPath "${CMAKE_PROJECT_NAME}")
@@ -106,7 +106,7 @@ else()
     set(installIncDir "${CMAKE_INSTALL_INCLUDEDIR}")
 endif()
 
-install(DIRECTORY "${CMAKE_SOURCE_DIR}/shaders" DESTINATION "${shadersDestPath}")
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/shaders" DESTINATION "${shadersDestPath}")
 
 # The first command is a dummy, it doesn't actually create its output: it's
 # only needed to force re-running of gen_version.cmake for the case when we've changed


### PR DESCRIPTION
The CMAKE_BINARY_DIR refers to build directory root. But when this library is built as subproject (add_directory) the build directory of library should be reffered as CMAKE_CURRENT_BINARY_DIR.